### PR TITLE
Update readme and add link to repository to the landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ Etsimme opettajia, opiskelijoita ja kaikkia opetuksesta kiinnostuneita osallistu
 2. Tutustu ohjeisiin: Lue projektin ohjeet ja säännöt, jotka löydät myös Githubista.
 3. Aloita osallistuminen: Valitse sinua kiinnostava osa-alue ja ala osallistumaan.
 
-### Yhteydenotto
-
-Jos sinulla on kysymyksiä tai ehdotuksia, voit ottaa meihin yhteyttä sähköpostitse: info@oppikirjasto.fi. Olemme täällä auttamassa sinua!
-
 ### Liity yhteisöömme
 
 Tehdään yhdessä oppimisesta parempaa ja tasavertaisempaa kaikille Suomen koululaisille. Liity projektiimme ja osallistu uuden, avoimen ja ilmaisen oppikirjaston rakentamiseen!

--- a/README.md
+++ b/README.md
@@ -2,9 +2,45 @@
 
 Emmekö voisi tehdä peruskoulun opetussuunnitelmaan perustuvat oppikirjat yhdessä, ja niin että kaikki saisivat lukea niitä vapaasti.
 
-Alternative approach on how to create and present Finnish school books.
+Oppikirjasto.fi on uusi, avoin, maksuton ja kattava digitaalinen oppimateriaalikirjasto yläkoulun oppilaille Suomessa. Tekoälyn avulla generoidut oppikirjat kattavat koko yläasteen opetussuunnitelman kaikissa aineissa. Tavoitteemme on tarjota kaikille Suomen koululaisille parhaimmat mahdolliset opetusmateriaalit ja näin tehdä oppimisesta tasavertaisempaa.
 
-### Commands
+## Miten voit osallistua?
+
+Etsimme opettajia, opiskelijoita ja kaikkia opetuksesta kiinnostuneita osallistumaan yhteisön rakentamiseen ja avoimien oppimateriaalien kehittämiseen. Voit auttaa monin eri tavoin:
+
+### 1. Kirjojen tarkistus ja laadun parantaminen
+- Anna palautetta: Lue oppikirjojamme ja anna palautetta mahdollisista virheistä tai parannuskohteista.
+- Ehdota muutoksia: Voit ehdottaa muutoksia ja parannuksia suoraan tähän Github-repositorioon.
+
+### 2. Sisällöntuotanto ja päivitys
+- Kirjoita uusia lukuja: Voit kirjoittaa uusia lukuja tai osioita oppikirjoihin.
+- Päivitä olemassa olevia: Päivitä ja laajenna jo olemassa olevaa sisältöä.
+
+### 3. Käytännön apu
+- Tekninen tuki: Osallistu tekniseen kehitykseen ja paranna sivuston käytettävyyttä.
+- Markkinointi ja viestintä: Levitä sanaa projektistamme ja tuo lisää osallistujia mukaan.
+
+### Miten aloittaa?
+
+1. Luo käyttäjätili GihHub-palveluun, jotta voit osallistua keskusteluun ja seuraamaan projektin edistymistä.
+2. Tutustu ohjeisiin: Lue projektin ohjeet ja säännöt, jotka löydät myös Githubista.
+3. Aloita osallistuminen: Valitse sinua kiinnostava osa-alue ja ala osallistumaan.
+
+### Yhteydenotto
+
+Jos sinulla on kysymyksiä tai ehdotuksia, voit ottaa meihin yhteyttä sähköpostitse: info@oppikirjasto.fi. Olemme täällä auttamassa sinua!
+
+### Liity yhteisöömme
+
+Tehdään yhdessä oppimisesta parempaa ja tasavertaisempaa kaikille Suomen koululaisille. Liity projektiimme ja osallistu uuden, avoimen ja ilmaisen oppikirjaston rakentamiseen!
+
+### How to develop and run locally
+
+- Requirements: Git, Node and Npm
+- clone repository from cmd / terminal with command `git clone https://github.com/taturl/oppikirjasto.git`
+- from command line change directory to the new directory with `cd oppikirjasto`
+- run `npm install` to install dependencies
+- run `npm run dev` to start local development server at [localhost:4321](localhost:4321) 
 
 All commands are run from the root of the project, from a terminal:
 

--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -156,7 +156,9 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
       </div>
 
       <div class="items-center flex justify-between w-full md:w-auto">
-        <!-- Top right corner github icon and link to the repository -->
+        <!-- 
+          Top right corner github icon and link to the repository. Taken from https://github.com/tholman/github-corners with MIT Licence. Copyright (c) 2016 Tim Holman
+        -->
         <a href="https://github.com/taturl/oppikirjasto" class="github-corner" aria-label="View source on GitHub">
           <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#fff; color:#151513; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
             <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>

--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -40,7 +40,7 @@ const {
   actions = [],
   isSticky = false,
   isDark = false,
-  isFullWidth = false,
+  isFullWidth = true,
   showToggleTheme = false,
   showRssFeed = false,
   position = 'center',
@@ -153,6 +153,16 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
             ''
           )
         }
+      </div>
+
+      <div class="items-center flex justify-between w-full md:w-auto">
+        <!-- Top right corner github icon and link to the repository -->
+        <a href="https://github.com/taturl/oppikirjasto" class="github-corner" aria-label="View source on GitHub">
+          <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#fff; color:#151513; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+            <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+          </svg>
+        </a>
+        <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
       </div>
     </div>
   </div>

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -83,6 +83,7 @@ export const headerData = {
       text: 'Ammatit',
       href: getPermalink('books/7-9/ammatit'),
     },
+    /* Links currently hidden from the navigation as the page content is lacking */
     /*
     {
       text: 'Haku',

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -83,6 +83,7 @@ export const headerData = {
       text: 'Ammatit',
       href: getPermalink('books/7-9/ammatit'),
     },
+    /*
     {
       text: 'Haku',
       href: getPermalink('haku'),
@@ -91,5 +92,6 @@ export const headerData = {
       text: 'Paperi',
       href: getPermalink('paperi'),
     },
+    */
   ],
 };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,51 @@ const metadata = {
     <div
       class="mx-auto prose prose-lg max-w-4xl dark:prose-invert dark:prose-headings:text-slate-300 prose-md prose-headings:font-heading prose-headings:leading-tighter prose-headings:tracking-tighter prose-headings:font-bold prose-a:text-blue-600 dark:prose-a:text-blue-400 prose-img:rounded-md prose-img:shadow-lg mt-8"
     >
-      Tältä sivustolta löydät yläkoulun 7-9 luokkien vapaat oppikirjat.
+    <h1>Tervetuloa Oppikirjastoon!</h1>
+
+    <p>
+      Oppikirjasto.fi on uusi, avoin, maksuton ja kattava digitaalinen oppimateriaalikirjasto yläkoulun oppilaille Suomessa. Tekoälyn avulla generoidut oppikirjat kattavat koko yläasteen opetussuunnitelman kaikissa aineissa. Tavoitteemme on tarjota kaikille Suomen koululaisille parhaimmat mahdolliset opetusmateriaalit ja näin tehdä oppimisesta tasavertaisempaa.
+    </p>
+
+    <h2>Miten voit osallistua?</h2>
+    
+    <p>
+      Etsimme opettajia, opiskelijoita ja kaikkia opetuksesta kiinnostuneita osallistumaan yhteisön rakentamiseen ja avoimien oppimateriaalien kehittämiseen. Voit auttaa monin eri tavoin:
+    </p>
+
+    <h3>1. Kirjojen tarkistus ja laadun parantaminen</h3>
+    <ul>
+      <li>Anna palautetta: Lue oppikirjojamme ja anna palautetta mahdollisista virheistä tai parannuskohteista.</li>
+      <li>Ehdota muutoksia: Voit ehdottaa muutoksia ja parannuksia suoraan Github-repositorioon osoitteessa <a href="https://github.com/taturl/oppikirjasto">github.com/taturl/oppikirjasto</a></li>
+    </ul>
+    
+    <h3>2. Sisällöntuotanto ja päivitys</h3>
+    <ul>
+      <li>Kirjoita uusia lukuja: Voit kirjoittaa uusia lukuja tai osioita oppikirjoihin.</li>
+      <li>Päivitä olemassa olevia: Päivitä ja laajenna jo olemassa olevaa sisältöä.</li>
+    </ul>
+    
+    <h3>3. Käytännön apu</h3>
+    <ul>
+      <li>Tekninen tuki: Osallistu tekniseen kehitykseen ja paranna sivuston käytettävyyttä.</li>
+      <li>Markkinointi ja viestintä: Levitä sanaa projektistamme ja tuo lisää osallistujia mukaan.</li>
+    </ul>
+    
+    <h3>Miten aloittaa?</h3>
+    <ol>
+      <li>Luo käyttäjätili GihHub-palveluun, jotta voit osallistua keskusteluun ja seuraamaan projektin edistymistä.</li>
+      <li>Tutustu ohjeisiin: Lue projektin ohjeet ja säännöt, jotka löydät myös Githubista.</li>
+      <li>Aloita osallistuminen: Valitse sinua kiinnostava osa-alue ja ala osallistumaan.</li>
+    </ol>
+    
+    <p>
+      Tehdään yhdessä oppimisesta parempaa ja tasavertaisempaa kaikille Suomen koululaisille. Liity projektiimme ja osallistu uuden, avoimen ja ilmaisen oppikirjaston rakentamiseen!
+    </p>
+
+    <p>
+      Tämä sivusto ja sen sisältö on avointa koodia MIT-lisenssillä.
+    </p>
+    
     </div>
   </section>
 </Layout>


### PR DESCRIPTION
- Updated readme with more informative content and added same information to the landing page. Content generated by ChatGpt.
- Added GitHub-corner to the top right corner of each page inside header section
- Hid pages '/Haku' and '/Paperi' as they did not have working content